### PR TITLE
Stop calling the `_tokenProvider` object, and instead it's method `getToken`

### DIFF
--- a/Spicetify/Services/Session.ts
+++ b/Spicetify/Services/Session.ts
@@ -98,7 +98,7 @@ export const GetSpotifyAccessToken = (): Promise<string> => {
 
 	// Otherwise, fetch a new access-token
 	accessTokenPromise = (
-		SpotifyPlatform.AuthorizationAPI._tokenProvider()
+		SpotifyPlatform.AuthorizationAPI._tokenProvider.getToken()
 		.then(
 			(result: TokenProviderResponse) => {
 				tokenProviderResponse = result, accessTokenPromise = Promise.resolve(result.accessToken)


### PR DESCRIPTION
Currently, the `Session` service calls the `_tokenProvider` object instead of its child method `getToken` (which returns what we actually want).

This fixes at least the following issues in a repository that uses this service:
- https://github.com/surfbryce/beautiful-lyrics/issues/635
- https://github.com/surfbryce/beautiful-lyrics/issues/634
- https://github.com/surfbryce/beautiful-lyrics/issues/633
- https://github.com/surfbryce/beautiful-lyrics/issues/632
- https://github.com/surfbryce/beautiful-lyrics/issues/630
- https://github.com/surfbryce/beautiful-lyrics/issues/628
- https://github.com/surfbryce/beautiful-lyrics/issues/625
- https://github.com/surfbryce/beautiful-lyrics/issues/624
- https://github.com/surfbryce/beautiful-lyrics/issues/622
- https://github.com/surfbryce/beautiful-lyrics/issues/621
- https://github.com/surfbryce/beautiful-lyrics/issues/619
- https://github.com/surfbryce/beautiful-lyrics/issues/617
(and possibly more, there are too many duplicates at this point)